### PR TITLE
Feat/tcp

### DIFF
--- a/cmd/tcplistener/main.go
+++ b/cmd/tcplistener/main.go
@@ -22,12 +22,12 @@ func main() {
 			fmt.Println("could not accept connection:", err)
 			continue
 		}
-		fmt.Println("connection accepted")
+		fmt.Println("tcp connection accepted")
 		linesChan := getLinesChannel(conn)
 		for line := range linesChan {
 			fmt.Println(line)
 		}
-		fmt.Println("connection closed")
+		fmt.Println("tcp connection closed")
 	}
 }
 

--- a/cmd/udpsender/main.go
+++ b/cmd/udpsender/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+)
+
+func main() {
+	udpAddr, err := net.ResolveUDPAddr("udp", "localhost:42069")
+	if err != nil {
+		fmt.Println("could not find udp address:", err)
+		os.Exit(1)
+	}
+	conn, err := net.DialUDP("udp", nil, udpAddr)
+	if err != nil {
+		fmt.Println("could not dial udp address:", err)
+		os.Exit(1)
+	}
+	defer func() {
+		err := conn.Close()
+		if err != nil {
+			fmt.Println("error cloding the udp address:", err)
+		}
+	}()
+
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		fmt.Print("> ")
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			fmt.Println("could not read the input:", err)
+		}
+
+		n, err := conn.Write([]byte(line))
+		if err != nil {
+			fmt.Println("could not write the line", err)
+		}
+		fmt.Printf("wrote %d bytes\n", n)
+	}
+
+}


### PR DESCRIPTION
This pull request introduces significant changes to the network communication functionality by replacing the previous file-based TCP listener with a true TCP server and adding a new UDP sender utility. The main themes are the migration from file I/O to network I/O and the addition of UDP client functionality.

**TCP Listener Refactor:**

* Changed `cmd/tcplistener/main.go` to listen for TCP connections on port 42069 instead of reading from a file, allowing dynamic processing of incoming network data.
* Updated the `getLinesChannel` function to read from a `net.Conn` (TCP connection) rather than a file, enabling line-by-line processing of data received over the network.

**UDP Sender Addition:**

* Added a new utility in `cmd/udpsender/main.go` that reads input from the user and sends it as UDP packets to `localhost:42069`, providing a simple way to send messages over UDP.