### PR TITLE
Feat/requests

### DIFF
--- a/cmd/tcplistener/main.go
+++ b/cmd/tcplistener/main.go
@@ -1,12 +1,11 @@
 package main
 
 import (
-	"errors"
 	"fmt"
-	"io"
 	"net"
 	"os"
-	"strings"
+
+	"github.com/AmiyoKm/httpfromtcp/internal/request"
 )
 
 func main() {
@@ -23,41 +22,14 @@ func main() {
 			continue
 		}
 		fmt.Println("tcp connection accepted")
-		linesChan := getLinesChannel(conn)
-		for line := range linesChan {
-			fmt.Println(line)
+
+		req, err := request.RequestFromReader(conn)
+		if err != nil {
+			fmt.Println("error :", err)
 		}
+
+		fmt.Printf("Request line:\n- Method: %s\n- Target: %s\n- Version: %s\n", req.RequestLine.Method, req.RequestLine.RequestTarget, req.RequestLine.HttpVersion)
+
 		fmt.Println("tcp connection closed")
 	}
-}
-
-func getLinesChannel(c net.Conn) <-chan string {
-	lines := make(chan string)
-	go func() {
-		defer c.Close()
-		defer close(lines)
-		currentLineContents := ""
-		for {
-			b := make([]byte, 8)
-			n, err := c.Read(b)
-			if err != nil {
-				if currentLineContents != "" {
-					lines <- currentLineContents
-				}
-				if errors.Is(err, io.EOF) {
-					break
-				}
-				fmt.Printf("error: %s\n", err.Error())
-				return
-			}
-			str := string(b[:n])
-			parts := strings.Split(str, "\n")
-			for i := 0; i < len(parts)-1; i++ {
-				lines <- fmt.Sprintf("%s%s", currentLineContents, parts[i])
-				currentLineContents = ""
-			}
-			currentLineContents += parts[len(parts)-1]
-		}
-	}()
-	return lines
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/AmiyoKm/httpfromtcp
 
 go 1.24.6
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -1,13 +1,71 @@
 package request
 
 import (
+	"bytes"
 	"fmt"
 	"io"
-	"strings"
 )
+
+type parserState string
+
+const (
+	StateInit  parserState = "init"
+	StateDone  parserState = "done"
+	StateError parserState = "error"
+)
+
+var ErrorMalformedRequestLine = fmt.Errorf("malformed request-line")
+var ErrorUnsupportedHttpVersion = fmt.Errorf("unsupported http version")
+var ErrorRequestInErrorState = fmt.Errorf("request in error state")
+
+var SEPERATOR = []byte("\r\n")
 
 type Request struct {
 	RequestLine RequestLine
+	state       parserState
+}
+
+func NewRequest() *Request {
+	return &Request{
+		state: StateInit,
+	}
+}
+
+func (r *Request) parse(data []byte) (int, error) {
+	read := 0
+outer:
+	for {
+		switch r.state {
+		case StateError:
+			return 0, ErrorRequestInErrorState
+
+		case StateInit:
+			rl, n, err := parseRequestLine(data[read:])
+			if err != nil {
+				r.state = StateError
+				return 0, err
+			}
+
+			if n == 0 {
+				break outer
+			}
+
+			r.RequestLine = *rl
+			read += n
+			r.state = StateDone
+
+		case StateDone:
+			break outer
+		}
+	}
+	return read, nil
+}
+
+func (r *Request) done() bool {
+	return r.state == StateDone
+}
+func (r *Request) error() bool {
+	return r.state == StateError
 }
 
 type RequestLine struct {
@@ -16,45 +74,64 @@ type RequestLine struct {
 	Method        string
 }
 
+func parseRequestLine(b []byte) (*RequestLine, int, error) {
+	idx := bytes.Index(b, SEPERATOR)
+	if idx == -1 {
+		return nil, 0, nil
+	}
+
+	startLine := b[:idx]
+	read := idx + len(SEPERATOR)
+
+	parts := bytes.Split(startLine, []byte(" "))
+	if len(parts) != 3 {
+		return nil, read, ErrorMalformedRequestLine
+	}
+
+	httpParts := bytes.Split(parts[2], []byte("/"))
+	if len(httpParts) != 2 || string(httpParts[0]) != "HTTP" || string(httpParts[1]) != "1.1" {
+		return nil, read, ErrorMalformedRequestLine
+	}
+
+	method := string(parts[0])
+	if !isValidMethod(method) {
+		return nil, 0, ErrorMalformedRequestLine
+	}
+
+	target := string(parts[1])
+	if !isValidTarget(target) {
+		return nil, 0, ErrorMalformedRequestLine
+	}
+
+	rl := &RequestLine{
+		Method:        string(parts[0]),
+		RequestTarget: string(parts[1]),
+		HttpVersion:   string(httpParts[1]),
+	}
+
+	return rl, read, nil
+}
+
 func RequestFromReader(reader io.Reader) (*Request, error) {
 
-	b := make([]byte, 4096)
-	n, err := reader.Read(b)
-	if err != nil {
-		return nil, err
+	request := NewRequest()
+	buf := make([]byte, 4096)
+	bufLen := 0
+
+	for !request.done() && !request.error() {
+		n, err := reader.Read(buf[bufLen:])
+		if err != nil {
+			return nil, err
+		}
+
+		bufLen += n
+		readN, err := request.parse(buf[:bufLen])
+		if err != nil {
+			return nil, err
+		}
+
+		copy(buf, buf[readN:bufLen])
+		bufLen -= readN
 	}
-	line := string(b[:n])
-	headers := strings.Split(line, "\r\n")
-
-	parts := strings.Split(headers[0], " ")
-
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("one or more of the part missing from request line header , parts leghth : %d", len(parts))
-	}
-
-	method := parts[0]
-	if !isValidMethod(method) {
-		return nil, fmt.Errorf("not a valid method , method : %s", method)
-	}
-
-	target := parts[1]
-	if !isValidTarget(target) {
-		return nil, fmt.Errorf("invalid request target: %s", target)
-	}
-
-	httpProtocol := strings.Split(parts[2], "/")
-	version := httpProtocol[1]
-	if !isValidHttpVersion(version) {
-		return nil, fmt.Errorf("not a valid http version , verison : %s", version)
-	}
-
-	requestLine := RequestLine{
-		Method:        method,
-		RequestTarget: target,
-		HttpVersion:   version,
-	}
-
-	return &Request{
-		RequestLine: requestLine,
-	}, nil
+	return request, nil
 }

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -104,8 +104,8 @@ func parseRequestLine(b []byte) (*RequestLine, int, error) {
 	}
 
 	rl := &RequestLine{
-		Method:        string(parts[0]),
-		RequestTarget: string(parts[1]),
+		Method:        method,
+		RequestTarget: target,
 		HttpVersion:   string(httpParts[1]),
 	}
 

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -1,0 +1,60 @@
+package request
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type Request struct {
+	RequestLine RequestLine
+}
+
+type RequestLine struct {
+	HttpVersion   string
+	RequestTarget string
+	Method        string
+}
+
+func RequestFromReader(reader io.Reader) (*Request, error) {
+
+	b := make([]byte, 4096)
+	n, err := reader.Read(b)
+	if err != nil {
+		return nil, err
+	}
+	line := string(b[:n])
+	headers := strings.Split(line, "\r\n")
+
+	parts := strings.Split(headers[0], " ")
+
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("one or more of the part missing from request line header , parts leghth : %d", len(parts))
+	}
+
+	method := parts[0]
+	if !isValidMethod(method) {
+		return nil, fmt.Errorf("not a valid method , method : %s", method)
+	}
+
+	target := parts[1]
+	if !isValidTarget(target) {
+		return nil, fmt.Errorf("invalid request target: %s", target)
+	}
+
+	httpProtocol := strings.Split(parts[2], "/")
+	version := httpProtocol[1]
+	if !isValidHttpVersion(version) {
+		return nil, fmt.Errorf("not a valid http version , verison : %s", version)
+	}
+
+	requestLine := RequestLine{
+		Method:        method,
+		RequestTarget: target,
+		HttpVersion:   version,
+	}
+
+	return &Request{
+		RequestLine: requestLine,
+	}, nil
+}

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -1,6 +1,7 @@
 package request_test
 
 import (
+	"io"
 	"strings"
 	"testing"
 
@@ -9,40 +10,107 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type chunkReader struct {
+	data            string
+	numBytesPerRead int
+	pos             int
+}
+
+// Read reads up to len(p) or numBytesPerRead bytes from the string per call
+// its useful for simulating reading a variable number of bytes per chunk from a network connection
+func (cr *chunkReader) Read(p []byte) (n int, err error) {
+	if cr.pos >= len(cr.data) {
+		return 0, io.EOF
+	}
+	endIndex := min(cr.pos+cr.numBytesPerRead, len(cr.data))
+	n = copy(p, cr.data[cr.pos:endIndex])
+	cr.pos += n
+
+	return n, nil
+}
+
 func TestRequestLineParse(t *testing.T) {
-	// Test: Good GET Request line
-	r, err := request.RequestFromReader(strings.NewReader("GET / HTTP/1.1\r\nHost: localhost:42069\r\nUser-Agent: curl/7.81.0\r\nAccept: */*\r\n\r\n"))
-	require.NoError(t, err)
-	require.NotNil(t, r)
-	assert.Equal(t, "GET", r.RequestLine.Method)
-	assert.Equal(t, "/", r.RequestLine.RequestTarget)
-	assert.Equal(t, "1.1", r.RequestLine.HttpVersion)
+	testCases := []struct {
+		name            string
+		input           string
+		useChunkReader  bool
+		chunkSize       int
+		expectError     bool
+		expectedMethod  string
+		expectedTarget  string
+		expectedVersion string
+	}{
+		{
+			name:            "Good GET Request line (chunked)",
+			input:           "GET / HTTP/1.1\r\nHost: localhost:42069\r\nUser-Agent: curl/7.81.0\r\nAccept: */*\r\n\r\n",
+			useChunkReader:  true,
+			chunkSize:       3,
+			expectError:     false,
+			expectedMethod:  "GET",
+			expectedTarget:  "/",
+			expectedVersion: "1.1",
+		},
+		{
+			name:            "Good GET Request line with path",
+			input:           "GET /coffee HTTP/1.1\r\nHost: localhost:42069\r\nUser-Agent: curl/7.81.0\r\nAccept: */*\r\n\r\n",
+			useChunkReader:  true,
+			chunkSize:       1,
+			expectError:     false,
+			expectedMethod:  "GET",
+			expectedTarget:  "/coffee",
+			expectedVersion: "1.1",
+		},
+		{
+			name:            "Good POST Request with path",
+			input:           "POST /coffee HTTP/1.1\r\nHost: localhost:42069\r\nUser-Agent: curl/7.81.0\r\nContent-Type: application/json\r\nContent-Length: 22\r\n\r\n{\"flavor\":\"dark mode\"}",
+			useChunkReader:  true,
+			chunkSize:       1,
+			expectError:     false,
+			expectedMethod:  "POST",
+			expectedTarget:  "/coffee",
+			expectedVersion: "1.1",
+		},
+		{
+			name:           "Invalid number of parts in request line",
+			input:          "/coffee HTTP/1.1\r\nHost: localhost:42069\r\nUser-Agent: curl/7.81.0\r\nAccept: */*\r\n\r\n",
+			useChunkReader: true,
+			chunkSize:      1,
+			expectError:    true,
+		},
+		{
+			name:           "Invalid method (out of order) Request line",
+			input:          "/ GET HTTP/1.1\r\nHost: localhost:42069\r\nUser-Agent: curl/7.81.0\r\nAccept: */*\r\n\r\n",
+			useChunkReader: true,
+			chunkSize:      1,
+			expectError:    true,
+		},
+	}
 
-	// Test: Good GET Request line with path
-	r, err = request.RequestFromReader(strings.NewReader("GET /coffee HTTP/1.1\r\nHost: localhost:42069\r\nUser-Agent: curl/7.81.0\r\nAccept: */*\r\n\r\n"))
-	require.NoError(t, err)
-	require.NotNil(t, r)
-	assert.Equal(t, "GET", r.RequestLine.Method)
-	assert.Equal(t, "/coffee", r.RequestLine.RequestTarget)
-	assert.Equal(t, "1.1", r.RequestLine.HttpVersion)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var reader io.Reader
 
-	// Test: Good POST Request with path
-	r, err = request.RequestFromReader(strings.NewReader("POST /coffee HTTP/1.1\r\nHost: localhost:42069\r\nUser-Agent: curl/7.81.0\r\nContent-Type: application/json\r\nContent-Length: 22\r\n\r\n{\"flavor\":\"dark mode\"}"))
-	require.NoError(t, err)
-	require.NotNil(t, r)
-	assert.Equal(t, "POST", r.RequestLine.Method)
-	assert.Equal(t, "/coffee", r.RequestLine.RequestTarget)
-	assert.Equal(t, "1.1", r.RequestLine.HttpVersion)
+			if tc.useChunkReader {
+				reader = &chunkReader{
+					data:            tc.input,
+					numBytesPerRead: tc.chunkSize,
+				}
+			} else {
+				reader = strings.NewReader(tc.input)
+			}
 
-	// Test: Invalid number of parts in request line
-	_, err = request.RequestFromReader(strings.NewReader("/coffee HTTP/1.1\r\nHost: localhost:42069\r\nUser-Agent: curl/7.81.0\r\nAccept: */*\r\n\r\n"))
-	require.Error(t, err)
+			r, err := request.RequestFromReader(reader)
 
-	// Test: Invalid method (out of order) Request line
-	_, err = request.RequestFromReader(strings.NewReader("/ GET HTTP/1.1\r\nHost: localhost:42069\r\nUser-Agent: curl/7.81.0\r\nAccept: */*\r\n\r\n"))
-	require.Error(t, err)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
 
-	// Test: Invalid version in Request line
-	_, err = request.RequestFromReader(strings.NewReader("GET / HTTP/2.0\r\nHost: localhost:42069\r\nUser-Agent: curl/7.81.0\r\nAccept: */*\r\n\r\n"))
-	require.Error(t, err)
+			require.NoError(t, err)
+			require.NotNil(t, r)
+			assert.Equal(t, tc.expectedMethod, r.RequestLine.Method)
+			assert.Equal(t, tc.expectedTarget, r.RequestLine.RequestTarget)
+			assert.Equal(t, tc.expectedVersion, r.RequestLine.HttpVersion)
+		})
+	}
 }

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -1,0 +1,48 @@
+package request_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/AmiyoKm/httpfromtcp/internal/request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestLineParse(t *testing.T) {
+	// Test: Good GET Request line
+	r, err := request.RequestFromReader(strings.NewReader("GET / HTTP/1.1\r\nHost: localhost:42069\r\nUser-Agent: curl/7.81.0\r\nAccept: */*\r\n\r\n"))
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	assert.Equal(t, "GET", r.RequestLine.Method)
+	assert.Equal(t, "/", r.RequestLine.RequestTarget)
+	assert.Equal(t, "1.1", r.RequestLine.HttpVersion)
+
+	// Test: Good GET Request line with path
+	r, err = request.RequestFromReader(strings.NewReader("GET /coffee HTTP/1.1\r\nHost: localhost:42069\r\nUser-Agent: curl/7.81.0\r\nAccept: */*\r\n\r\n"))
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	assert.Equal(t, "GET", r.RequestLine.Method)
+	assert.Equal(t, "/coffee", r.RequestLine.RequestTarget)
+	assert.Equal(t, "1.1", r.RequestLine.HttpVersion)
+
+	// Test: Good POST Request with path
+	r, err = request.RequestFromReader(strings.NewReader("POST /coffee HTTP/1.1\r\nHost: localhost:42069\r\nUser-Agent: curl/7.81.0\r\nContent-Type: application/json\r\nContent-Length: 22\r\n\r\n{\"flavor\":\"dark mode\"}"))
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	assert.Equal(t, "POST", r.RequestLine.Method)
+	assert.Equal(t, "/coffee", r.RequestLine.RequestTarget)
+	assert.Equal(t, "1.1", r.RequestLine.HttpVersion)
+
+	// Test: Invalid number of parts in request line
+	_, err = request.RequestFromReader(strings.NewReader("/coffee HTTP/1.1\r\nHost: localhost:42069\r\nUser-Agent: curl/7.81.0\r\nAccept: */*\r\n\r\n"))
+	require.Error(t, err)
+
+	// Test: Invalid method (out of order) Request line
+	_, err = request.RequestFromReader(strings.NewReader("/ GET HTTP/1.1\r\nHost: localhost:42069\r\nUser-Agent: curl/7.81.0\r\nAccept: */*\r\n\r\n"))
+	require.Error(t, err)
+
+	// Test: Invalid version in Request line
+	_, err = request.RequestFromReader(strings.NewReader("GET / HTTP/2.0\r\nHost: localhost:42069\r\nUser-Agent: curl/7.81.0\r\nAccept: */*\r\n\r\n"))
+	require.Error(t, err)
+}

--- a/internal/request/valid.go
+++ b/internal/request/valid.go
@@ -16,14 +16,6 @@ func isValidMethod(method string) bool {
 	return validMethods[method]
 }
 
-var validHttpVersions = map[string]bool{
-	"1.1": true,
-}
-
-func isValidHttpVersion(version string) bool {
-	return validHttpVersions[version]
-}
-
 func isValidTarget(target string) bool {
 	if !strings.HasPrefix(target, "/") {
 		return false

--- a/internal/request/valid.go
+++ b/internal/request/valid.go
@@ -1,0 +1,39 @@
+package request
+
+import "strings"
+
+var validMethods = map[string]bool{
+	"GET":     true,
+	"POST":    true,
+	"PUT":     true,
+	"DELETE":  true,
+	"HEAD":    true,
+	"OPTIONS": true,
+	"PATCH":   true,
+}
+
+func isValidMethod(method string) bool {
+	return validMethods[method]
+}
+
+var validHttpVersions = map[string]bool{
+	"1.1": true,
+}
+
+func isValidHttpVersion(version string) bool {
+	return validHttpVersions[version]
+}
+
+func isValidTarget(target string) bool {
+	if !strings.HasPrefix(target, "/") {
+		return false
+	}
+	if strings.Contains(target, "../") {
+		return false
+	}
+	if len(target) > 2048 {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
This pull request introduces a new HTTP request parser module and refactors the TCP listener to use it, improving the code structure and adding robust request line parsing and validation. It also adds comprehensive tests for the parser and updates dependencies for testing support.

**Core HTTP request parsing and validation:**
* Added new `internal/request/request.go` module implementing a stateful HTTP request parser, including request line parsing and error handling for malformed requests and unsupported HTTP versions.
* Added request line validation logic in `internal/request/valid.go` to check for valid HTTP methods and targets, improving security and correctness.

**TCP listener refactor:**
* Refactored `cmd/tcplistener/main.go` to use the new request parser (`request.RequestFromReader`), replacing the previous line-based TCP reading logic with structured request parsing and improved output. [[1]](diffhunk://#diff-14a4b2c228b9f8e357b4b5acaddc0bbed1661ae1d741f68068ecc5b3ef14f7d4L4-R8) [[2]](diffhunk://#diff-14a4b2c228b9f8e357b4b5acaddc0bbed1661ae1d741f68068ecc5b3ef14f7d4L26-L62)

**Testing and dependencies:**
* Added `internal/request/request_test.go` with thorough unit tests covering various valid and invalid HTTP request lines, including chunked input simulation.
* Updated `go.mod` to include indirect dependencies for testing and YAML support.