### PR TITLE
Feat/chunked encoding

### DIFF
--- a/cmd/httpserver/handler.go
+++ b/cmd/httpserver/handler.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/AmiyoKm/httpfromtcp/internal/headers"
+	"github.com/AmiyoKm/httpfromtcp/internal/request"
+	"github.com/AmiyoKm/httpfromtcp/internal/response"
+	"github.com/AmiyoKm/httpfromtcp/internal/server"
+)
+
+var handler = server.Handler(func(w *response.Writer, r *request.Request) {
+	h := response.GetDefaultHeaders(0)
+	h.Replace("Content-Type", "text/html")
+	if strings.HasPrefix(r.RequestLine.RequestTarget, "/httpbin/stream") {
+		target := r.RequestLine.RequestTarget
+		res, err := http.Get("https://httpbin.org/" + target[len("/httpbin/"):])
+		if err != nil {
+			body := respond500()
+
+			w.WriteStatusLine(response.StatusInternalServerError)
+			h.Replace("Content-Length", strconv.Itoa(len(body)))
+			w.WriteHeaders(*h)
+			w.WriteBody(body)
+			return
+		}
+		w.WriteStatusLine(response.StatusOK)
+
+		h.Delete("Content-Length")
+		h.Set("transfer-encoding", "chunked")
+		h.Replace("Content-Type", "text/plain")
+		h.Set("Trailer", "X-Content-SHA256")
+		h.Set("Trailer", "X-Content-Length")
+		w.WriteHeaders(*h)
+
+		fullBody := []byte{}
+		for {
+			data := make([]byte, 32)
+			n, err := res.Body.Read(data)
+			if err != nil {
+				break
+			}
+
+			fullBody = append(fullBody, data[:n]...)
+			w.WriteChunkedBody(data[:n])
+		}
+
+		w.WriteChunkedBodyDone()
+
+		trailers := headers.NewHeaders()
+		encrypted := sha256.Sum256(fullBody)
+		trailers.Set("X-Content-SHA256", toStr(encrypted[:]))
+		trailers.Set("X-Content-Length", fmt.Sprintf("%d", len(fullBody)))
+
+		w.WriteHeaders(*trailers)
+
+		return
+	}
+
+	switch r.RequestLine.RequestTarget {
+	case "/yourproblem":
+		body := respond400()
+		w.WriteStatusLine(response.StatusBadRequest)
+		h.Replace("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeaders(*h)
+		w.WriteBody(body)
+	case "/myproblem":
+		body := respond500()
+
+		w.WriteStatusLine(response.StatusInternalServerError)
+		h.Replace("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeaders(*h)
+		w.WriteBody(body)
+	default:
+		body := respond200()
+		w.WriteStatusLine(response.StatusOK)
+		h.Replace("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeaders(*h)
+		w.WriteBody(body)
+	}
+})

--- a/cmd/httpserver/helpers.go
+++ b/cmd/httpserver/helpers.go
@@ -1,5 +1,10 @@
 package main
 
+import (
+	"bytes"
+	"fmt"
+)
+
 func respond400() []byte {
 	return []byte(`<html>
   <head>
@@ -35,4 +40,13 @@ func respond200() []byte {
 		headers.Replace("Content-Type", "text/html")
   </body>
 </html>`)
+}
+
+func toStr(byt []byte) string {
+	out := bytes.Buffer{}
+
+	for _, b := range byt {
+		out.Write([]byte(fmt.Sprintf("%02x", b)))
+	}
+	return out.String()
 }

--- a/cmd/httpserver/main.go
+++ b/cmd/httpserver/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -45,13 +44,12 @@ var handler = server.Handler(func(w *response.Writer, r *request.Request) {
 			if err != nil {
 				break
 			}
-			w.WriteBody([]byte(fmt.Sprintf("%x\r\n", n)))
-			w.WriteBody(data[:n])
-			w.WriteBody([]byte("\r\n"))
+			w.WriteChunkedBody(data[:n])
 		}
-		w.WriteBody([]byte("0\r\n\r\n"))
+		w.WriteChunkedBodyDone()
 		return
 	}
+
 	switch r.RequestLine.RequestTarget {
 	case "/yourproblem":
 		body := respond400()

--- a/cmd/httpserver/main.go
+++ b/cmd/httpserver/main.go
@@ -2,76 +2,14 @@ package main
 
 import (
 	"log"
-	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
-	"strings"
 	"syscall"
 
-	"github.com/AmiyoKm/httpfromtcp/internal/request"
-	"github.com/AmiyoKm/httpfromtcp/internal/response"
 	"github.com/AmiyoKm/httpfromtcp/internal/server"
 )
 
 const port = 42069
-
-var handler = server.Handler(func(w *response.Writer, r *request.Request) {
-	headers := response.GetDefaultHeaders(0)
-	headers.Replace("Content-Type", "text/html")
-	if strings.HasPrefix(r.RequestLine.RequestTarget, "/httpbin/stream") {
-		target := r.RequestLine.RequestTarget
-		res, err := http.Get("https://httpbin.org/" + target[len("/httpbin/"):])
-		if err != nil {
-			body := respond500()
-
-			w.WriteStatusLine(response.StatusInternalServerError)
-			headers.Replace("Content-Length", strconv.Itoa(len(body)))
-			w.WriteHeaders(*headers)
-			w.WriteBody(body)
-			return
-		}
-		w.WriteStatusLine(response.StatusOK)
-
-		headers.Delete("Content-Length")
-		headers.Set("transfer-encoding", "chunked")
-		headers.Replace("Content-Type", "text/plain")
-		w.WriteHeaders(*headers)
-
-		for {
-			data := make([]byte, 32)
-			n, err := res.Body.Read(data)
-			if err != nil {
-				break
-			}
-			w.WriteChunkedBody(data[:n])
-		}
-		w.WriteChunkedBodyDone()
-		return
-	}
-
-	switch r.RequestLine.RequestTarget {
-	case "/yourproblem":
-		body := respond400()
-		w.WriteStatusLine(response.StatusBadRequest)
-		headers.Replace("Content-Length", strconv.Itoa(len(body)))
-		w.WriteHeaders(*headers)
-		w.WriteBody(body)
-	case "/myproblem":
-		body := respond500()
-
-		w.WriteStatusLine(response.StatusInternalServerError)
-		headers.Replace("Content-Length", strconv.Itoa(len(body)))
-		w.WriteHeaders(*headers)
-		w.WriteBody(body)
-	default:
-		body := respond200()
-		w.WriteStatusLine(response.StatusOK)
-		headers.Replace("Content-Length", strconv.Itoa(len(body)))
-		w.WriteHeaders(*headers)
-		w.WriteBody(body)
-	}
-})
 
 func main() {
 	server, err := server.Serve(port, handler)

--- a/cmd/httpserver/main.go
+++ b/cmd/httpserver/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/AmiyoKm/httpfromtcp/internal/request"
@@ -17,26 +20,58 @@ const port = 42069
 var handler = server.Handler(func(w *response.Writer, r *request.Request) {
 	headers := response.GetDefaultHeaders(0)
 	headers.Replace("Content-Type", "text/html")
+	if strings.HasPrefix(r.RequestLine.RequestTarget, "/httpbin/stream") {
+		target := r.RequestLine.RequestTarget
+		res, err := http.Get("https://httpbin.org/" + target[len("/httpbin/"):])
+		if err != nil {
+			body := respond500()
+
+			w.WriteStatusLine(response.StatusInternalServerError)
+			headers.Replace("Content-Length", strconv.Itoa(len(body)))
+			w.WriteHeaders(*headers)
+			w.WriteBody(body)
+			return
+		}
+		w.WriteStatusLine(response.StatusOK)
+
+		headers.Delete("Content-Length")
+		headers.Set("transfer-encoding", "chunked")
+		headers.Replace("Content-Type", "text/plain")
+		w.WriteHeaders(*headers)
+
+		for {
+			data := make([]byte, 32)
+			n, err := res.Body.Read(data)
+			if err != nil {
+				break
+			}
+			w.WriteBody([]byte(fmt.Sprintf("%x\r\n", n)))
+			w.WriteBody(data[:n])
+			w.WriteBody([]byte("\r\n"))
+		}
+		w.WriteBody([]byte("0\r\n\r\n"))
+		return
+	}
 	switch r.RequestLine.RequestTarget {
 	case "/yourproblem":
 		body := respond400()
 		w.WriteStatusLine(response.StatusBadRequest)
 		headers.Replace("Content-Length", strconv.Itoa(len(body)))
 		w.WriteHeaders(*headers)
-		w.WriteBody(respond400())
+		w.WriteBody(body)
 	case "/myproblem":
 		body := respond500()
 
 		w.WriteStatusLine(response.StatusInternalServerError)
 		headers.Replace("Content-Length", strconv.Itoa(len(body)))
 		w.WriteHeaders(*headers)
-		w.WriteBody(respond500())
+		w.WriteBody(body)
 	default:
 		body := respond200()
 		w.WriteStatusLine(response.StatusOK)
 		headers.Replace("Content-Length", strconv.Itoa(len(body)))
 		w.WriteHeaders(*headers)
-		w.WriteBody(respond200())
+		w.WriteBody(body)
 	}
 })
 

--- a/internal/headers/headers.go
+++ b/internal/headers/headers.go
@@ -71,6 +71,10 @@ func (h *Headers) Replace(key string, val string) {
 	key = strings.ToLower(key)
 	h.headers[key] = val
 }
+func (h *Headers) Delete(key string) {
+	key = strings.ToLower(key)
+	delete(h.headers, key)
+}
 
 func (h *Headers) ForEach(cb func(key, value string)) {
 	for key, value := range h.headers {

--- a/internal/response/response.go
+++ b/internal/response/response.go
@@ -75,7 +75,7 @@ func (w *Writer) WriteChunkedBody(p []byte) (int, error) {
 }
 
 func (w *Writer) WriteChunkedBodyDone() (int, error) {
-	finalChunk := []byte("0\r\n\r\n")
+	finalChunk := []byte("0\r\n")
 	n, err := w.writer.Write(finalChunk)
 	return n, err
 }

--- a/internal/response/response.go
+++ b/internal/response/response.go
@@ -50,6 +50,36 @@ func (w *Writer) WriteBody(p []byte) (int, error) {
 	return n, err
 }
 
+func (w *Writer) WriteChunkedBody(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	chunkSize := fmt.Sprintf("%x\r\n", len(p))
+	_, err := w.writer.Write([]byte(chunkSize))
+	if err != nil {
+		return 0, err
+	}
+
+	n, err := w.writer.Write(p)
+	if err != nil {
+		return n, err
+	}
+
+	_, err = w.writer.Write([]byte("\r\n"))
+	if err != nil {
+		return n, err
+	}
+
+	return n, nil
+}
+
+func (w *Writer) WriteChunkedBodyDone() (int, error) {
+	finalChunk := []byte("0\r\n\r\n")
+	n, err := w.writer.Write(finalChunk)
+	return n, err
+}
+
 const (
 	StatusOK                  StatusCode = 200
 	StatusBadRequest          StatusCode = 400


### PR DESCRIPTION
This pull request refactors the HTTP server handler logic to support chunked transfer encoding for streaming responses and improves header management. The main changes include moving the handler implementation to a dedicated file, adding support for chunked responses with trailers, and enhancing utilities for headers and byte formatting.

**Streaming and chunked response support:**

* Added logic in `cmd/httpserver/handler.go` to handle `/httpbin/stream` requests by proxying to httpbin.org, streaming the response using chunked transfer encoding, and appending trailers with SHA256 and content length information.
* Implemented `WriteChunkedBody` and `WriteChunkedBodyDone` methods in `internal/response/response.go` to support writing chunked HTTP responses.

**Handler refactoring and organization:**

* Moved the main handler logic from `cmd/httpserver/main.go` to a new `cmd/httpserver/handler.go` file, cleaning up the main file and improving separation of concerns. [[1]](diffhunk://#diff-ac9d4aa597dfa35d64367429a2fa0fa370c7ae5b6c23b510fc5b750f8c99a83fL7-L42) [[2]](diffhunk://#diff-c3f2ec7a2a4e7cdd42ae0d5fbac3721079d7bed9b9446026b0b9806953fd1301R1-R85)

**Header management improvements:**

* Added a `Delete` method to the `Headers` type in `internal/headers/headers.go` to allow removal of headers, which is used for managing `Content-Length` in chunked responses.

**Utility enhancements:**

* Added a `toStr` helper in `cmd/httpserver/helpers.go` to format byte slices as hexadecimal strings for use in trailers.
* Updated imports in `cmd/httpserver/helpers.go` to support new utilities.